### PR TITLE
Fix readthedocs badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 Introduction
 ============
 
-.. image:: https://readthedocs.org/projects/adafruit-circuitpython-ssd1681/badge/?version=latest:target: https://circuitpython.readthedocs.io/projects/ssd1681/en/latest/
+.. image:: https://readthedocs.org/projects/adafruit-circuitpython-ssd1681/badge/?version=latest
+    :target: https://circuitpython.readthedocs.io/projects/ssd1681/en/latest/
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/discord/327254708534116352.svg


### PR DESCRIPTION
I think this may need to be fixed in the cookie cutter as well.