### PR TITLE
Update the pixel_shader usage of OnDiskBitmap

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,12 @@ Usage Example
     f = open("/display-ruler.bmp", "rb")
 
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/ssd1681_simpletest.py
+++ b/examples/ssd1681_simpletest.py
@@ -41,7 +41,12 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)


### PR DESCRIPTION
OnDiskBitmap has had incompatible changes in `7.0.0-alpha.3` - Ref: https://github.com/adafruit/circuitpython/pull/4823
This PR is part of a group of updates for this change - https://github.com/adafruit/circuitpython/issues/4982

This PR updates the library to the combined usage for CP6 & CP7.
It has not been tested as I do not have the hardware.