### PR TITLE
Enable uploading of the driver to PyPI.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,6 @@ Introduction
 
 CircuitPython `displayio` driver for SSD1681-based ePaper displays
 
-
 Dependencies
 =============
 This driver depends on:
@@ -38,6 +37,30 @@ Adafruit 1.54" Tri-Color eInk / ePaper 200x200 Display with SRAM
 
 `Purchase one from the Adafruit shop <http://www.adafruit.com/products/4868>`_
 
+Installing from PyPI
+=====================
+
+On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
+PyPI <https://pypi.org/project/adafruit-circuitpython-ssd1681/>`_. To install for current user:
+
+.. code-block:: shell
+
+    pip3 install adafruit-circuitpython-ssd1681
+
+To install system-wide (this may be required in some cases):
+
+.. code-block:: shell
+
+    sudo pip3 install adafruit-circuitpython-ssd1681
+
+To install in a virtual environment in your current project:
+
+.. code-block:: shell
+
+    mkdir project-name && cd project-name
+    python3 -m venv .env
+    source .env/bin/activate
+    pip3 install adafruit-circuitpython-ssd1681
 
 Usage Example
 =============
@@ -47,7 +70,7 @@ Usage Example
     import time
     import board
     import displayio
-    import adafruit_ssd1608
+    import adafruit_ssd1681
 
     displayio.release_displays()
 
@@ -63,22 +86,28 @@ Usage Example
     )
     time.sleep(1)
 
-    display = adafruit_ssd1608.SSD1608(
+    display = adafruit_ssd1681.SSD1681(
         display_bus, width=200, height=200, busy_pin=epd_busy, rotation=180
     )
 
     g = displayio.Group()
 
+    # CircuitPython 6 & 7 compatible
     f = open("/display-ruler.bmp", "rb")
-
     pic = displayio.OnDiskBitmap(f)
-    t = displayio.TileGrid(pic, pixel_shader=displayio.ColorConverter())
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+
+    # # CircuitPython 7 compatible only
+    # pic = displayio.OnDiskBitmap("/display-ruler.bmp")
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
+
     g.append(t)
 
     display.show(g)
 
     display.refresh()
-
     print("refreshed")
 
     time.sleep(120)
@@ -93,5 +122,5 @@ before contributing to help this project stay welcoming.
 Documentation
 =============
 
-For information on building library documentation, please check out
-`this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.
+For information on building library documentation, please check out `this guide
+<https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+from setuptools import setup, find_packages
+
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="adafruit-circuitpython-ssd1681",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    description="CircuitPython `displayio` drivers for SSD1681-based ePaper displays",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    # The project's main homepage.
+    url="https://github.com/adafruit/Adafruit_CircuitPython_SSD1681",
+    # Author details
+    author="Adafruit Industries",
+    author_email="circuitpython@adafruit.com",
+    install_requires=["Adafruit-Blinka"],
+    # Choose your license
+    license="MIT",
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: System :: Hardware",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+    ],
+    # What does your project relate to?
+    keywords="adafruit blinka circuitpython micropython ssd1681 displayio epd epaper",
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
+    #       CHANGE `py_modules=['...']` TO `packages=['...']`
+    py_modules=["adafruit_ssd1681"],
+)

--- a/setup.py.disabled
+++ b/setup.py.disabled
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
-#
-# SPDX-License-Identifier: MIT
-
-"""
-This library is not deployed to PyPI. It is either a board-specific helper library, or
-does not make sense for use on or is incompatible with single board computers and Linux.
-"""


### PR DESCRIPTION
This allows the driver to used with Blinka
Ref: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/336

Also, update the 'Usage' example on the `README` to actually use this driver.

