### PR TITLE
FourWire support for 8.x.x and 9.x.x

### DIFF
--- a/adafruit_ssd1681.py
+++ b/adafruit_ssd1681.py
@@ -25,7 +25,13 @@ Implementation Notes
 
 """
 
-import displayio
+# Support both 8.x.x and 9.x.x. Change when 8.x.x is discontinued as a stable release.
+try:
+    from fourwire import FourWire
+    from epaperdisplay import EPaperDisplay
+except ImportError:
+    from displayio import FourWire
+    from displayio import EPaperDisplay
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_SSD1681.git"
@@ -45,7 +51,7 @@ _STOP_SEQUENCE = b"\x10\x81\x01\x64"  # Deep Sleep
 
 
 # pylint: disable=too-few-public-methods
-class SSD1681(displayio.EPaperDisplay):
+class SSD1681(EPaperDisplay):
     r"""SSD1681 driver
 
     :param bus: The data bus the display is on
@@ -61,7 +67,7 @@ class SSD1681(displayio.EPaperDisplay):
           Display rotation
     """
 
-    def __init__(self, bus: displayio.FourWire, **kwargs) -> None:
+    def __init__(self, bus: FourWire, **kwargs) -> None:
         start_sequence = bytearray(_START_SEQUENCE)
 
         width = kwargs["width"]

--- a/examples/ssd1681_four_corners.py
+++ b/examples/ssd1681_four_corners.py
@@ -13,9 +13,16 @@ import time
 import board
 import busio
 import displayio
-import fourwire
 import terminalio
 import adafruit_ssd1681
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from fourwire import FourWire
+except ImportError:
+    from displayio import FourWire
+
 
 displayio.release_displays()
 
@@ -28,7 +35,7 @@ epd_dc = board.EPD_DC
 epd_reset = board.EPD_RESET
 epd_busy = board.EPD_BUSY
 
-display_bus = fourwire.FourWire(
+display_bus = FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 display = adafruit_ssd1681.SSD1681(

--- a/examples/ssd1681_simpletest.py
+++ b/examples/ssd1681_simpletest.py
@@ -12,8 +12,14 @@ Supported products:
 import time
 import board
 import displayio
-import fourwire
 import adafruit_ssd1681
+
+# Compatibility with both CircuitPython 8.x.x and 9.x.x.
+# Remove after 8.x.x is no longer a supported release.
+try:
+    from fourwire import FourWire
+except ImportError:
+    from displayio import FourWire
 
 displayio.release_displays()
 
@@ -24,7 +30,7 @@ epd_dc = board.D10
 epd_reset = board.D5
 epd_busy = board.D6
 
-display_bus = fourwire.FourWire(
+display_bus = FourWire(
     spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
 )
 time.sleep(1)


### PR DESCRIPTION
Jumped the gun here on 9.x.x-only support.